### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :move_to_index, except: [:index, :new]
+  before_action :move_to_index, except: [:index, :new, :show]
   before_action :authenticate_user!, only: [:new]
 
   def index
@@ -19,8 +19,9 @@ class ItemsController < ApplicationController
     end
   end
 
-  # def show
-  # end
+  def show
+    @item = Item.find(params[:id])
+  end
 
   private
 
@@ -34,10 +35,3 @@ class ItemsController < ApplicationController
     redirect_to action: :index unless user_signed_in?
   end
 end
-
-# def move_to_index
-#  prototype = Prototype.find(params[:id])
-#  unless current_user.id == prototype.user_id
-#    redirect_to action: :index
-#  end
-# end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -7,6 +7,7 @@ class Item < ApplicationRecord
   belongs_to :prefecture
   belongs_to :scheduled_delivery
   has_one_attached :image
+  has_one :record
 
   validates :product, :explanation, :image, presence: true
 

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -1,0 +1,6 @@
+class Record < ApplicationRecord
+  #extend ActiveHash::Associations::ActiveRecordExtensions
+  belongs_to :user
+  belongs_to :item
+  #validates :prefecture_id, numericality: { other_than: 1, message: "can't be blank" }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,4 @@
 class User < ApplicationRecord
-  # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
@@ -22,4 +20,5 @@ class User < ApplicationRecord
   validates :birth_date, presence: true
 
   has_many :items
+  has_many :records
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -152,11 +152,11 @@
           <div class='item-img-content'>
             <%= image_tag item.image, class: "item-img" %>
 
-            <%# 商品が売れていればsold outを表示しましょう %>
+            <% if item.record.present? %>
             <div class='sold-out'>
               <span>Sold Out!!</span>
             </div>
-            <%# //商品が売れていればsold outを表示しましょう %>
+            <% end %>
 
           </div>
           <div class='item-info'>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -148,7 +148,7 @@
     <% else %>
       <% @items.each do |item| %>
         <li class='list'>
-          <%= link_to "#" do %>
+          <%= link_to item_path(item.id) do %>
           <div class='item-img-content'>
             <%= image_tag item.image, class: "item-img" %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -6,14 +6,16 @@
     <h2 class="name">
       <%= @item.product %>
     </h2>
+    
     <div class="item-img-content">
       <%= image_tag @item.image ,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
+      <% if @item.record.present? %>
       <div class="sold-out">
         <span>Sold Out!!</span>
       </div>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
+      <% end %>
     </div>
+
     <div class="item-price-box">
       <span class="item-price">
         <%= @item.price %>円
@@ -31,40 +33,41 @@
 
       <% else %>
         <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-
-        <div class="item-explain-box">
-          <span><%= @item.explanation %></span>
-        </div>
-        <table class="detail-table">
-          <tbody>
-            <tr>
-              <th class="detail-item">出品者</th>
-              <td class="detail-value"><%= @item.user.nickname %></td>
-            </tr>
-            <tr>
-              <th class="detail-item">カテゴリー</th>
-              <td class="detail-value"><%= Category.find(@item.category_id)[:name] %></td>
-            </tr>
-            <tr>
-              <th class="detail-item">商品の状態</th>
-              <td class="detail-value"><%= SalesStatus.find(@item.sales_status_id)[:name] %></td>
-            </tr>
-            <tr>
-              <th class="detail-item">配送料の負担</th>
-              <td class="detail-value"><%= ShippingFeeStatus.find(@item.shipping_fee_status_id)[:name] %></td>
-            </tr>
-            <tr>
-              <th class="detail-item">発送元の地域</th>
-              <td class="detail-value"><%= Prefecture.find(@item.prefecture_id)[:name] %></td>
-            </tr>
-            <tr>
-              <th class="detail-item">発送日の目安</th>
-              <td class="detail-value"><%= ScheduledDelivery.find(@item.scheduled_delivery_id)[:name] %></td>
-            </tr>
-          </tbody>
-        </table>
       <% end %>
+
+      <div class="item-explain-box">
+        <span><%= @item.explanation %></span>
+      </div>
+      <table class="detail-table">
+        <tbody>
+          <tr>
+            <th class="detail-item">出品者</th>
+            <td class="detail-value"><%= @item.user.nickname %></td>
+          </tr>
+          <tr>
+            <th class="detail-item">カテゴリー</th>
+            <td class="detail-value"><%= Category.find(@item.category_id)[:name] %></td>
+          </tr>
+          <tr>
+            <th class="detail-item">商品の状態</th>
+            <td class="detail-value"><%= SalesStatus.find(@item.sales_status_id)[:name] %></td>
+          </tr>
+          <tr>
+            <th class="detail-item">配送料の負担</th>
+            <td class="detail-value"><%= ShippingFeeStatus.find(@item.shipping_fee_status_id)[:name] %></td>
+          </tr>
+          <tr>
+            <th class="detail-item">発送元の地域</th>
+            <td class="detail-value"><%= Prefecture.find(@item.prefecture_id)[:name] %></td>
+          </tr>
+          <tr>
+            <th class="detail-item">発送日の目安</th>
+            <td class="detail-value"><%= ScheduledDelivery.find(@item.scheduled_delivery_id)[:name] %></td>
+          </tr>
+        </tbody>
+      </table>
     <% end %>
+    
     <div class="option">
         <div class="favorite-btn">
           <%= image_tag "star.png" ,class:"favorite-star-icon" ,width:"20",height:"20"%>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,10 +4,10 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.product %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class="sold-out">
         <span>Sold Out!!</span>
@@ -16,67 +16,69 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= @item.price %>
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= ShippingFeeStatus.find(@item.shipping_fee_status_id)[:name] %>
       </span>
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    <% if user_signed_in? && current_user.id == @item.user_id %>
+      <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+      <p class="or-text">or</p>
+      <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
 
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-    <p class="or-text">or</p>
-    <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
+    <% else %>
+      <%# 商品が売れていない場合はこちらを表示しましょう %>
+      <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+      <%# //商品が売れていない場合はこちらを表示しましょう %>
 
 
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+      <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
-    <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
-    </div>
-    <table class="detail-table">
-      <tbody>
-        <tr>
-          <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
-        </tr>
-        <tr>
-          <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
-        </tr>
-        <tr>
-          <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
-        </tr>
-        <tr>
-          <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
-        </tr>
-        <tr>
-          <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
-        </tr>
-        <tr>
-          <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
-        </tr>
-      </tbody>
-    </table>
-    <div class="option">
-      <div class="favorite-btn">
-        <%= image_tag "star.png" ,class:"favorite-star-icon" ,width:"20",height:"20"%>
-        <span>お気に入り 0</span>
+      <div class="item-explain-box">
+        <span><%= "商品説明" %></span>
       </div>
-      <div class="report-btn">
-        <%= image_tag "flag.png" ,class:"report-flag-icon" ,width:"20",height:"20"%>
-        <span>不適切な商品の通報</span>
+      <table class="detail-table">
+        <tbody>
+          <tr>
+            <th class="detail-item">出品者</th>
+            <td class="detail-value"><%= @item.user.nickname %></td>
+          </tr>
+          <tr>
+            <th class="detail-item">カテゴリー</th>
+            <td class="detail-value"><%= Category.find(@item.category_id)[:name] %></td>
+          </tr>
+          <tr>
+            <th class="detail-item">商品の状態</th>
+            <td class="detail-value"><%= SalesStatus.find(@item.sales_status_id)[:name] %></td>
+          </tr>
+          <tr>
+            <th class="detail-item">配送料の負担</th>
+            <td class="detail-value"><%= ShippingFeeStatus.find(@item.shipping_fee_status_id)[:name] %></td>
+          </tr>
+          <tr>
+            <th class="detail-item">発送元の地域</th>
+            <td class="detail-value"><%= Prefecture.find(@item.prefecture_id)[:name] %></td>
+          </tr>
+          <tr>
+            <th class="detail-item">発送日の目安</th>
+            <td class="detail-value"><%= ScheduledDelivery.find(@item.scheduled_delivery_id)[:name] %></td>
+          </tr>
+        </tbody>
+      </table>
+      <div class="option">
+        <div class="favorite-btn">
+          <%= image_tag "star.png" ,class:"favorite-star-icon" ,width:"20",height:"20"%>
+          <span>お気に入り 0</span>
+        </div>
+        <div class="report-btn">
+          <%= image_tag "flag.png" ,class:"report-flag-icon" ,width:"20",height:"20"%>
+          <span>不適切な商品の通報</span>
+        </div>
       </div>
-    </div>
+    <% end %>
   </div>
   <%# /商品の概要 %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -16,59 +16,58 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        <%= @item.price %>
+        <%= @item.price %>円
       </span>
       <span class="item-postage">
         <%= ShippingFeeStatus.find(@item.shipping_fee_status_id)[:name] %>
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-    <% if user_signed_in? && current_user.id == @item.user_id %>
-      <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-      <p class="or-text">or</p>
-      <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+    <% if user_signed_in? && @item.record.blank? %>
+      <% if current_user.id == @item.user_id %>
+        <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+        <p class="or-text">or</p>
+        <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
 
-    <% else %>
-      <%# 商品が売れていない場合はこちらを表示しましょう %>
-      <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-      <%# //商品が売れていない場合はこちらを表示しましょう %>
+      <% else %>
+        <%# 商品が売れていない場合はこちらを表示しましょう %>
+        <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+        <%# //商品が売れていない場合はこちらを表示しましょう %>
 
-
-      <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-      <div class="item-explain-box">
-        <span><%= "商品説明" %></span>
-      </div>
-      <table class="detail-table">
-        <tbody>
-          <tr>
-            <th class="detail-item">出品者</th>
-            <td class="detail-value"><%= @item.user.nickname %></td>
-          </tr>
-          <tr>
-            <th class="detail-item">カテゴリー</th>
-            <td class="detail-value"><%= Category.find(@item.category_id)[:name] %></td>
-          </tr>
-          <tr>
-            <th class="detail-item">商品の状態</th>
-            <td class="detail-value"><%= SalesStatus.find(@item.sales_status_id)[:name] %></td>
-          </tr>
-          <tr>
-            <th class="detail-item">配送料の負担</th>
-            <td class="detail-value"><%= ShippingFeeStatus.find(@item.shipping_fee_status_id)[:name] %></td>
-          </tr>
-          <tr>
-            <th class="detail-item">発送元の地域</th>
-            <td class="detail-value"><%= Prefecture.find(@item.prefecture_id)[:name] %></td>
-          </tr>
-          <tr>
-            <th class="detail-item">発送日の目安</th>
-            <td class="detail-value"><%= ScheduledDelivery.find(@item.scheduled_delivery_id)[:name] %></td>
-          </tr>
-        </tbody>
-      </table>
-      <div class="option">
+        <div class="item-explain-box">
+          <span><%= @item.explanation %></span>
+        </div>
+        <table class="detail-table">
+          <tbody>
+            <tr>
+              <th class="detail-item">出品者</th>
+              <td class="detail-value"><%= @item.user.nickname %></td>
+            </tr>
+            <tr>
+              <th class="detail-item">カテゴリー</th>
+              <td class="detail-value"><%= Category.find(@item.category_id)[:name] %></td>
+            </tr>
+            <tr>
+              <th class="detail-item">商品の状態</th>
+              <td class="detail-value"><%= SalesStatus.find(@item.sales_status_id)[:name] %></td>
+            </tr>
+            <tr>
+              <th class="detail-item">配送料の負担</th>
+              <td class="detail-value"><%= ShippingFeeStatus.find(@item.shipping_fee_status_id)[:name] %></td>
+            </tr>
+            <tr>
+              <th class="detail-item">発送元の地域</th>
+              <td class="detail-value"><%= Prefecture.find(@item.prefecture_id)[:name] %></td>
+            </tr>
+            <tr>
+              <th class="detail-item">発送日の目安</th>
+              <td class="detail-value"><%= ScheduledDelivery.find(@item.scheduled_delivery_id)[:name] %></td>
+            </tr>
+          </tbody>
+        </table>
+      <% end %>
+    <% end %>
+    <div class="option">
         <div class="favorite-btn">
           <%= image_tag "star.png" ,class:"favorite-star-icon" ,width:"20",height:"20"%>
           <span>お気に入り 0</span>
@@ -77,8 +76,7 @@
           <%= image_tag "flag.png" ,class:"report-flag-icon" ,width:"20",height:"20"%>
           <span>不適切な商品の通報</span>
         </div>
-      </div>
-    <% end %>
+    </div>
   </div>
   <%# /商品の概要 %>
 
@@ -105,7 +103,7 @@
     </a>
   </div>
   <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class="another-item"><%= Category.find(@item.category_id)[:name] %>をもっと見る</a>
   <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -30,9 +30,7 @@
         <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
 
       <% else %>
-        <%# 商品が売れていない場合はこちらを表示しましょう %>
         <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-        <%# //商品が売れていない場合はこちらを表示しましょう %>
 
         <div class="item-explain-box">
           <span><%= @item.explanation %></span>
@@ -102,9 +100,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
   <a href="#" class="another-item"><%= Category.find(@item.category_id)[:name] %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 
 <%= render "shared/footer" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items, only: [:index, :new, :create]
+  resources :items, only: [:index, :new, :create, :show]
 end

--- a/db/migrate/20211013011701_create_records.rb
+++ b/db/migrate/20211013011701_create_records.rb
@@ -1,0 +1,8 @@
+class CreateRecords < ActiveRecord::Migration[6.0]
+  def change
+    create_table :records do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :item, null: false, foreign_key: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_05_075452) do
+ActiveRecord::Schema.define(version: 2021_10_13_011701) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -48,6 +48,13 @@ ActiveRecord::Schema.define(version: 2021_10_05_075452) do
     t.index ["user_id"], name: "index_items_on_user_id"
   end
 
+  create_table "records", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "item_id", null: false
+    t.index ["item_id"], name: "index_records_on_item_id"
+    t.index ["user_id"], name: "index_records_on_user_id"
+  end
+
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "nickname", null: false
     t.string "email", default: "", null: false
@@ -68,4 +75,6 @@ ActiveRecord::Schema.define(version: 2021_10_05_075452) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "items", "users"
+  add_foreign_key "records", "items"
+  add_foreign_key "records", "users"
 end

--- a/spec/factories/records.rb
+++ b/spec/factories/records.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :record do
+    
+  end
+end

--- a/spec/models/record_spec.rb
+++ b/spec/models/record_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Record, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
# What
商品詳細表示機能の実装

# Why
出品者かそれ以外か、またはログインしていないユーザーかによって
商品詳細の表示内容を切り替えるため。
また、出品状況によっても表示内容を変えるため。

# URL
ログイン状態かつ、自身が出品した商品の詳細ページに遷移する場合
https://gyazo.com/608f465e7dd3b863f3efa442c08e65d4

ログイン状態かつ、自身が出品していない商品の詳細ページに遷移する場合
https://gyazo.com/aa0aee9f71951ca287d484334dbde155

ログイン状態かつ、売却済み商品の詳細ページに遷移する場合
https://gyazo.com/e10d688566aeabd4e3b53e04f4ddd000

ログインしていない状態で商品の詳細ページに遷移する場合
https://gyazo.com/b45d667e88d709a56af439d07ab79d02
